### PR TITLE
Properly check ./ directory for crate name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,8 @@ fn main() -> io::Result<()> {
 
     if is_crate_directory(crate_path) {
       let crate_name = crate_path
+        .canonicalize()
+        .unwrap_or_default()
         .file_name()
         .and_then(|name| name.to_str())
         .unwrap_or_default()


### PR DESCRIPTION
#What this does?

I've added ```canonicalize()``` to the file path check in [here](https://github.com/YassinEldeeb/rust-panic-analyzer/blob/da8c25e2963bf18369c4645c84cd7740fe9dd33d/src/main.rs#L60). This allows that panic-analyzer can properly check ./ directory for being a possible cargo crate and allows executing panic-analyzer in the main directory of a crate itself, instead of having to step out of it.

Previously, the filepath was un-canonicalized, resulting in panic-analyzer trying to extract a crate name from "./"-string, which failed and the current ./ directory could never be analyzed.

# Why?
Normally, you execute cargo commands inside the main directory of a crate and this previously returned with 0 analyzed crates. Now, one can analyze the crate, while executing ```cargo panic-analyzer``` from within the crate's main directory