### PR TITLE
Made the default to display crates having only array-index-accesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ You can also do the same with files as the following:
 IGNORED_FILES=./src/tests/something.rs,./src/tests/else.rs cargo panic-analyzer > audit.md
 ```
 
+For ignoring crates that only use array indexing without triggering other audits define the `IGNORE_ARRAY_INDEX_ONLY_CRATES`` environment variable.
+
+```sh
+IGNORE_ARRAY_INDEX_ONLY_CRATES=1 cargo panic-analyzer > audit.md
+```
+
 A potential panic is not necessarily bad, sometimes errors are unrecoverable, and we have to panic.
 If your panic is intentional, you can add a comment before the line that has the potential panicing code like this:
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,6 +43,8 @@ fn main() -> io::Result<()> {
     .map(|s| s.to_string())
     .collect::<HashSet<String>>();
 
+  let ignore_array_index_only_crates = std::env::var("IGNORE_ARRAY_INDEX_ONLY_CRATES").is_ok();
+
   let mut crate_counts: HashMap<String, HashMap<&str, (usize, String)>> = HashMap::new();
   let mut expected_annotations: HashMap<String, Vec<(String, String, String)>> = HashMap::new();
 
@@ -143,16 +145,18 @@ fn main() -> io::Result<()> {
     }
   }
 
-  // adjust counts for crates with only 'array_index' errors
-  for pattern_counts in crate_counts.values_mut() {
-    let only_array_index_errors = pattern_counts
-      .iter()
-      .all(|(pattern, &(count, _))| *pattern == "array_index" || count == 0);
+  if ignore_array_index_only_crates {
+    // adjust counts for crates with only 'array_index' errors
+    for pattern_counts in crate_counts.values_mut() {
+      let only_array_index_errors = pattern_counts
+        .iter()
+        .all(|(pattern, &(count, _))| *pattern == "array_index" || count == 0);
 
-    if only_array_index_errors {
-      if let Some((count, _)) = pattern_counts.get_mut("array_index") {
-        total_actual_audits = total_actual_audits - *count;
-        *count = 0;
+      if only_array_index_errors {
+        if let Some((count, _)) = pattern_counts.get_mut("array_index") {
+          total_actual_audits = total_actual_audits - *count;
+          *count = 0;
+        }
       }
     }
   }


### PR DESCRIPTION
# Previous behavior

Panic-Analyzer would previously hide crates that only have array-access audit triggers and no other audit triggers.

# Why the change

As we want to see all audit triggers for possible panics, suppressing crates with only array-access audit triggers as a default is surprising and counter-intuitive for us.

# What this does

Made it default, that panic-analyzer would display all audit triggers, even if the crate only has array-access audit triggers.
Added an environment variable to restore previous behavior and hide crates that have only array-audit triggers again.
Ultimately making the default of panic-analyzer the most restrictive setting possible.
