### PR TITLE
Parsing rust cratename from toml, instead of filepath

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -29,6 +51,7 @@ version = "0.1.4"
 dependencies = [
  "regex",
  "serde_json",
+ "toml",
  "walkdir",
 ]
 
@@ -126,6 +149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -134,6 +166,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -182,3 +248,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ path = "src/main.rs"
 [dependencies]
 regex = "1.10.2"
 serde_json = "1.0.111"
+toml = "0.8.12"
 walkdir = "2.4.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,22 +63,16 @@ fn main() -> io::Result<()> {
       let toml_path = get_toml_path(crate_path);
       let toml_content = read_to_string(toml_path).unwrap_or_default();
       let toml_parsed = toml_content.parse::<Table>().unwrap_or_default();
-      let crate_name = toml_parsed["package"]["name"].as_str().unwrap_or_default();
+      let crate_name = toml_parsed["package"]["name"].as_str().unwrap_or_default().to_string();
 
       if crate_name.is_empty()
         || crate_name == exclude_crate_name
-        || ignored_crates.contains(&crate_name)
+        || ignored_crates.contains(&crate_name.as_str())
       {
         continue;
       }
 
       let mut pattern_counts: HashMap<&str, (usize, String)> = HashMap::new();
-
-      let crate_name = crate_path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or_default()
-        .to_string();
 
       for entry in WalkDir::new(crate_path).into_iter().filter_map(|e| e.ok()) {
         if entry.file_type().is_file() && entry.path().extension().map_or(false, |ext| ext == "rs")

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,18 @@ fn main() -> io::Result<()> {
       let toml_path = get_toml_path(crate_path);
       let toml_content = read_to_string(toml_path).unwrap_or_default();
       let toml_parsed = toml_content.parse::<Table>().unwrap_or_default();
+
+      // check if relevant toml keys exist. panics if keys do not exist and access is attempted
+      if !toml_parsed.contains_key("package") {
+        continue;
+      }
+      if !match toml_parsed["package"].as_table() {
+        Some(x) => x.contains_key("name"),
+        None => continue
+      } {
+        continue;
+      }
+
       let crate_name = toml_parsed["package"]["name"].as_str().unwrap_or_default().to_string();
 
       if crate_name.is_empty()


### PR DESCRIPTION
# What this does

Panic-Analyzer pulls the crate name of the analyzed crate from the respective Cargo.toml file instead of pulling it out of the directory path

## Why is this desired?

Since the crate name is not necessarily included in the filepath to a crate, it is safer to pull the crate name from the crate's Cargo.toml instead of the crate's file path

## How is this achieved?

We are using the ```toml``` crate to parse toml files. To do so, the toml file is read into string (since the ```toml``` crate does not yet allow parsing of the toml from file directly). This should be ok since toml files are usually not gigabytes in size. The toml is then parsed for the "name" key under the "package" section.